### PR TITLE
chore: add api versioning

### DIFF
--- a/src/api/GoActive.WebApi/Endpoints/Shared/CreateSketchEndpoint.cs
+++ b/src/api/GoActive.WebApi/Endpoints/Shared/CreateSketchEndpoint.cs
@@ -5,6 +5,7 @@ using GoActive.WebApi.Infrastructure.Endpoints;
 using GoActive.WebApi.Infrastructure.Filters;
 using GoActive.Modules.Geo.Application.Commands;
 using System.Net;
+using Microsoft.OpenApi.Models;
 
 namespace GoActive.WebApi.Endpoints.Shared;
 
@@ -36,8 +37,12 @@ internal class CreateSketchEndpoint : IEndpoint
                         return TypedResults.CreatedAtRoute(result.Value);
                     })
             .WithRequestValidation<CreateSketchRequest>()
-            .WithName("CreateSketch")
-            .WithTags("Sketches")
             .ProducesProblem((int)HttpStatusCode.InternalServerError)
-            .WithOpenApi();
+            .WithOpenApi(options => new(options)
+            {
+                OperationId = "CreateSketch",
+                Description = "Use this method to create sketch (draft) you can customise later",
+                Tags = [new OpenApiTag() { Name = "Sketches" }],
+                Summary = "Creates sketch of fitness geo-object"
+            });
 }

--- a/src/api/GoActive.WebApi/Infrastructure/Constants.cs
+++ b/src/api/GoActive.WebApi/Infrastructure/Constants.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+using Asp.Versioning;
+
+namespace GoActive.WebApi.Infrastructure;
+
+internal static class Constants
+{
+    // WARNING! strange bug
+    // if 'api version prefix' contains one symbol only -> this symbol shouldn't be presented in 'api version status'
+    // otherwise the route map issue occurs (HTTP 404)
+    internal const string ApiVersionPrefix = "v";
+    private const string ApiVesrionStatus = "prealpha";
+    internal const string ApiVersionFormat = "VVV";
+
+    internal static ApiVersion DefaultApiVersion = new(1, status: ApiVesrionStatus);
+    internal static string ApiName = Assembly.GetAssembly(typeof(Program))?.GetName()?.Name!;
+}

--- a/src/api/GoActive.WebApi/Infrastructure/OpenApi/ConfigureSwaggerOptions.cs
+++ b/src/api/GoActive.WebApi/Infrastructure/OpenApi/ConfigureSwaggerOptions.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning.ApiExplorer;
+
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GoActive.WebApi.Infrastructure.OpenApi;
+
+internal class ConfigureSwaggerOptions : IConfigureNamedOptions<SwaggerGenOptions>
+{
+    private readonly IApiVersionDescriptionProvider _versionProvider;
+
+    public ConfigureSwaggerOptions(IApiVersionDescriptionProvider versionProvider)
+    {
+        ArgumentNullException.ThrowIfNull(versionProvider);
+        _versionProvider = versionProvider;
+    }
+
+
+    public void Configure(string? name, SwaggerGenOptions options) => Configure(options);
+
+    public void Configure(SwaggerGenOptions options)
+    {
+        foreach (var description in _versionProvider.ApiVersionDescriptions)
+        {
+            var formattedVersion =
+                $"{Constants.ApiVersionPrefix}{description.ApiVersion.ToString(Constants.ApiVersionFormat)}";
+
+            var openApiInfo = new OpenApiInfo
+            {
+                Title = $"{Constants.ApiName} {formattedVersion}",
+                Version = formattedVersion
+            };
+            options.SwaggerDoc(description.GroupName, openApiInfo);
+        }
+    }
+}

--- a/src/api/GoActive.WebApi/Program.cs
+++ b/src/api/GoActive.WebApi/Program.cs
@@ -1,8 +1,9 @@
 using FluentValidation;
 using Asp.Versioning;
-
 using GoActive.WebApi.Infrastructure.Endpoints;
 using GoActive.Modules.Geo.Application.Commands;
+using GoActive.WebApi.Infrastructure.OpenApi;
+using GoActive.WebApi.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,6 +22,7 @@ builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 // Register Api Versioning
 builder.Services.AddApiVersioning(options =>
 {
+    options.DefaultApiVersion = Constants.DefaultApiVersion;
     options.ReportApiVersions = true;
     options.AssumeDefaultVersionWhenUnspecified = true;
     options.ApiVersionReader = ApiVersionReader.Combine(
@@ -29,38 +31,43 @@ builder.Services.AddApiVersioning(options =>
 })
 .AddApiExplorer(options =>
 {
-    options.GroupNameFormat = "'v'V";
+    options.GroupNameFormat = $"'{Constants.ApiVersionPrefix}'{Constants.ApiVersionFormat}";
     options.SubstituteApiVersionInUrl = true;
-
 });
 
 // Register Swagger OpenAPI
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.ConfigureOptions<ConfigureSwaggerOptions>();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
-
-app.UseHttpsRedirection();
-
 var apiVersionSet = app.NewApiVersionSet()
-    .HasApiVersion(new ApiVersion(1))
-    // .HasApiVersion(new ApiVersion(1, status: "preview"))
-    // .HasApiVersion(new ApiVersion(DateOnly.FromDateTime(DateTime.Today), status: "preview"))
+    .HasApiVersion(Constants.DefaultApiVersion)
     .ReportApiVersions()
     .Build();
 
 var versionedGroup = app
-    .MapGroup("api/v{version:apiVersion}")
+    .MapGroup($"api/{Constants.ApiVersionPrefix}{{version:apiVersion}}")
     .WithApiVersionSet(apiVersionSet);
 
 app.MapEndpoints(versionedGroup);
+
+if (!app.Environment.IsProduction())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(options =>
+    {
+        foreach (var description in app.DescribeApiVersions())
+        {
+            options.SwaggerEndpoint(
+                $"/swagger/{description.GroupName}/swagger.json",
+                $"{Constants.ApiName} {description.GroupName}");
+        }
+    });
+}
+
+app.UseHttpsRedirection();
 
 app.Run();

--- a/src/modules/geo/GoActive.Modules.Geo.Application/CommandHandlers/CreateSketchCommandHandler.cs
+++ b/src/modules/geo/GoActive.Modules.Geo.Application/CommandHandlers/CreateSketchCommandHandler.cs
@@ -10,28 +10,19 @@ internal class CreateSketchCommandHandler : IRequestHandler<CreateSketchCommand,
 {
     public Task<Result<Guid>> Handle(CreateSketchCommand command, CancellationToken cancellation)
     {
-        try
+        // TODO: check the existence of the same sketch and return Result.Fail if it is so
+        var newId = GeoDataId.FromValue(Guid.NewGuid());
+        var latitude = new Latitude(command.Location.Latitude);
+        var longitude = new Longitude(command.Location.Longitude);
+
+        var geoData = new GeoData(newId, Title.FromValue(command.Title))
         {
-            var newId = GeoDataId.FromValue(Guid.NewGuid());
-            var latitude = new Latitude(command.Location.Latitude);
-            var longitude = new Longitude(command.Location.Longitude);
+            CreatedAt = DateTime.UtcNow,
+            Center = new GeoCoordinate(Location: new(latitude, longitude), Altitude: default)
+        };
 
-            var geoData = new GeoData(newId, Title.FromValue(command.Title))
-            {
-                CreatedAt = DateTime.UtcNow,
-                Center = new GeoCoordinate(Location: new(latitude, longitude), Altitude: default)
-            };
+        //TODO: invoke save to database here
 
-            //TODO: invoke save to database here
-
-            return Task.FromResult(Result.Ok(geoData.Id.Value));
-        }
-        // TODO: catch the specific business excception
-        catch (Exception ex)
-        {
-
-            // TODO: log the exception
-            return Task.FromResult(Result.Fail<Guid>(ex.Message));
-        }
+        return Task.FromResult(Result.Ok(geoData.Id.Value));
     }
 }


### PR DESCRIPTION
API versioning support has been added. 
Useful references: 
[One](https://weblogs.asp.net/ricardoperes/asp-net-core-api-versioning) 
[Two](https://www.milanjovanovic.tech/blog/api-versioning-in-aspnetcore)

Mentioned authors: @m-jovanovic 